### PR TITLE
Prepare version 0.4.0 release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+# Version 0.4.0
+Changes in version 0.4.0 include:
+- Support three modes of execution: MATLAB, compiled MATLAB executables with MATLAB runtime, or Docker
+- The SINGE workflow has been split in GLG and Aggregate steps
+- A wrapper script supports running the GLG and Aggregate steps individually or the entire workflow
+- Increase robustness of hyperparameter parsing
+- Add script to generate hyperparameter file
+- Add usage guidelines
+- Update Docker images are built on Travis CI
+- Generalize Docker image to work outside the SINGE git repository
+- Add default entrypoint to Docker image
+- Test cases assert that the source code matches the compiled MATLAB executables
+- All remaining instances of the old name SCINGE have been changed to SINGE
+- Rename data1/tf.mat to data1/gene_list.mat and added data3 dataset
+
 # Version 0.3.0
 Version 0.3.0 contains optimizations that greatly increase SINGE's speed but can change its output:
 - Switch to single precision for the kernel matrix

--- a/code/SINGE.m
+++ b/code/SINGE.m
@@ -8,7 +8,7 @@ function [ranked_edges, gene_influence] = SINGE(Data,gene_list,outdir,hyperparam
 % aggregation
 % hyperparameter_file = file path to text file containing all
 % hyperparameters
-SINGE_version = '0.3.0';
+SINGE_version = '0.4.0';
 display(SINGE_version);
 
 fid = fopen(hyperparameter_file);

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,7 +41,7 @@ ENV SINGE_RUNNING_IN_DOCKER 1
 
 # Download an intermediate version of the compiled SINGE executables for testing
 # Download the md5sums of the source .m files and binaries
-RUN md5=d4f3ad7f18d2c03a6e2f40179248680d && \
+RUN md5=fc1ffba71d68b09cb65fc35d1bf05222 && \
     wget --quiet https://www.biostat.wisc.edu/~gitter/tmp/$md5/SINGE_Test && \
     wget --quiet https://www.biostat.wisc.edu/~gitter/tmp/$md5/SINGE_GLG_Test && \
     wget --quiet https://www.biostat.wisc.edu/~gitter/tmp/$md5/SINGE_Aggregate && \


### PR DESCRIPTION
Summarizes changes in [commits](https://github.com/gitter-lab/SINGE/compare/v0.3.0...5586f0dd80e925ad6d459d6556f5646eb6f8ff90) and pull requests:
- #33 
- #34 
- #36 
- #37 
- #39 
- #42 
- #43
- #44 
- #45 
- #47 
- #48
- #50