### PR TITLE
Shared Storage Bug Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,11 @@ This example is part of the SINGE test code, which only runs when called from th
 - *runtime_dir* - Path to MATLAB R2018a runtime library
 
 **GLG hyperparameters:**
-- *--ID* - Identifier for GLG hyperparameter set
+- *--ID* - Numeric identifier for the GLG hyperparameter set, which should be unique for each hyperparameter set and replicate index
 - *--lambda* - Sparsity parameter (lambda = 0 results in a non-sparse solution)
-- *--dT* - Time resolution for GLG Test
-- *--num-lags* - Number of lags for GLG Test
-- *--kernel-width* - Gaussian kernel width for GLG Test
+- *--dT* - Time resolution for GLG test
+- *--num-lags* - Number of lags for GLG test
+- *--kernel-width* - Gaussian kernel width for GLG test
 - *--replicate* - Replicate index
 - *--family* - Distribution Family of the gene expression values (options = `gaussian`, `poisson`, default = `gaussian`)
 - *--prob-zero-removal* - For Zero-handling Strategy (default = 0)

--- a/code/SINGE_GLG_Test.m
+++ b/code/SINGE_GLG_Test.m
@@ -16,7 +16,10 @@ end
 resampling_method = {'holes';'burst'};
 %outpath
 % Use a temporary matfile to track intermediate state
-m = matfile('TempMat','Writable',true);
+% Create new file for each job ID to avoid bugs when storage is shared
+% between parallel jobs
+
+m = matfile(['TempMat' '_' num2str(params.ID)],'Writable',true);
 ptime = m.ptime;
 m.computeKp = 1;
 if ptime(end)~=100
@@ -68,5 +71,5 @@ end
 runtime = toc
 % File saving moved to iLasso_for_SINGE using matfile feature
 fprintf('Intermediate files saved.\n')
-delete TempMat.mat
+delete(['TempMat' '_' num2str(params.ID) '.mat']);
 end

--- a/code/SINGE_GLG_Test.m
+++ b/code/SINGE_GLG_Test.m
@@ -14,12 +14,13 @@ if isdeployed
     set(0,'DefaultFigureVisible','off');
 end
 resampling_method = {'holes';'burst'};
-%outpath
+
+
 % Use a temporary matfile to track intermediate state
 % Create new file for each job ID to avoid bugs when storage is shared
 % between parallel jobs
-
 m = matfile(['TempMat' '_' num2str(params.ID)],'Writable',true);
+
 ptime = m.ptime;
 m.computeKp = 1;
 if ptime(end)~=100
@@ -69,6 +70,7 @@ for irow = 1:1:LX
 end
 
 runtime = toc
+
 % File saving moved to iLasso_for_SINGE using matfile feature
 fprintf('Intermediate files saved.\n')
 delete(['TempMat' '_' num2str(params.ID) '.mat']);

--- a/code/parseParams.m
+++ b/code/parseParams.m
@@ -62,6 +62,16 @@ params.ID = stringcheck(params.ID);
 params.lambda = sort(params.lambda,'descend');
 params.p1 = params.dT*params.num_lags;
 params.DateNumber = datenum(params.date);
+
+% Create new file for each job ID to avoid bugs when storage is shared
+% between parallel jobs (Separated valid file and temp file creation for
+% this purpose).
+
+if (exist([Data '.mat'], 'file') == 2)
+        copyfile([Data '.mat'],['TempMat' '_' num2str(params.ID) '.mat']);
+elseif (exist(Data, 'file') == 2)
+        copyfile(Data,['TempMat' '_' num2str(params.ID) '.mat']);
+end
 end
 
 function y = isfilecomp(x)

--- a/code/parseParams.m
+++ b/code/parseParams.m
@@ -63,10 +63,9 @@ params.lambda = sort(params.lambda,'descend');
 params.p1 = params.dT*params.num_lags;
 params.DateNumber = datenum(params.date);
 
-% Create new file for each job ID to avoid bugs when storage is shared
-% between parallel jobs (Separated valid file and temp file creation for
-% this purpose).
-
+% Create new file for each job ID to avoid collisions when storage is shared
+% between parallel jobs (separated valid file and temp file creation for
+% this purpose)
 if (exist([Data '.mat'], 'file') == 2)
         copyfile([Data '.mat'],['TempMat' '_' num2str(params.ID) '.mat']);
 elseif (exist(Data, 'file') == 2)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,20 +36,20 @@ ENV SINGE_RUNNING_IN_DOCKER 1
 
 # Download the compiled SINGE executables from the stable release
 # md5sum of v0.4.0 SINGE_GLG_Test is fc1ffba71d68b09cb65fc35d1bf05222
-RUN tag=v0.4.0 && \
-    wget --quiet https://github.com/gitter-lab/SINGE/releases/download/$tag/SINGE_Test && \
-    wget --quiet https://github.com/gitter-lab/SINGE/releases/download/$tag/SINGE_GLG_Test && \
-    wget --quiet https://github.com/gitter-lab/SINGE/releases/download/$tag/SINGE_Aggregate && \
-    wget --quiet https://github.com/gitter-lab/SINGE/releases/download/$tag/code.md5 && \
-    chmod u+x SINGE_* && \
-    mv SINGE_Test tests/SINGE_Test
+#RUN tag=v0.4.0 && \
+#    wget --quiet https://github.com/gitter-lab/SINGE/releases/download/$tag/SINGE_Test && \
+#    wget --quiet https://github.com/gitter-lab/SINGE/releases/download/$tag/SINGE_GLG_Test && \
+#    wget --quiet https://github.com/gitter-lab/SINGE/releases/download/$tag/SINGE_Aggregate && \
+#    wget --quiet https://github.com/gitter-lab/SINGE/releases/download/$tag/code.md5 && \
+#    chmod u+x SINGE_* && \
+#    mv SINGE_Test tests/SINGE_Test
 
 # Download an intermediate version of the compiled SINGE executables for testing
 # Download the md5sums of the source .m files and binaries
-#RUN md5=fc1ffba71d68b09cb65fc35d1bf05222 && \
-#    wget --quiet https://www.biostat.wisc.edu/~gitter/tmp/$md5/SINGE_Test && \
-#    wget --quiet https://www.biostat.wisc.edu/~gitter/tmp/$md5/SINGE_GLG_Test && \
-#    wget --quiet https://www.biostat.wisc.edu/~gitter/tmp/$md5/SINGE_Aggregate && \
-#    wget --quiet https://www.biostat.wisc.edu/~gitter/tmp/$md5/code.md5 && \
-#    chmod u+x SINGE_* && \
-#    mv SINGE_Test tests/SINGE_Test
+RUN md5=cbe289c204defe48f1a69fbe5326af0e && \
+    wget --quiet https://www.biostat.wisc.edu/~gitter/tmp/$md5/SINGE_Test && \
+    wget --quiet https://www.biostat.wisc.edu/~gitter/tmp/$md5/SINGE_GLG_Test && \
+    wget --quiet https://www.biostat.wisc.edu/~gitter/tmp/$md5/SINGE_Aggregate && \
+    wget --quiet https://www.biostat.wisc.edu/~gitter/tmp/$md5/code.md5 && \
+    chmod u+x SINGE_* && \
+    mv SINGE_Test tests/SINGE_Test


### PR DESCRIPTION
Create a new TempMat for each job ID to avoid overwriting errors caused by shared storage during parallel processing.